### PR TITLE
Add Diffbot-API-Node library to Contributed Libraries list

### DIFF
--- a/source/includes_erb/_introduction.md.erb
+++ b/source/includes_erb/_introduction.md.erb
@@ -1,10 +1,10 @@
 # Introduction
 
-Welcome to the Diffbot API Documentation. Diffbot enables you to extract articles, products, images, videos, discussions, and more from any web page! 
+Welcome to the Diffbot API Documentation. Diffbot enables you to extract articles, products, images, videos, discussions, and more from any web page!
 
 Using AI, computer vision, machine learning and natural language processing, Diffbot provides developers with numerous tools to understand and extract data from any web page.
 
-We have sample code for you as raw cURL requests and in PHP in the dark area to the right - more languages (Ruby and Python being first) are coming soon. cURL is shown by default, but you can use the tabs in the top right to switch the programming language. 
+We have sample code for you as raw cURL requests and in PHP in the dark area to the right - more languages (Ruby and Python being first) are coming soon. cURL is shown by default, but you can use the tabs in the top right to switch the programming language.
 
 If you notice the docs are unclear or that there's a typo, please don't be shy about clicking the "Suggest Edits" link in the left navbar! **We're working hard to keep these docs up to date**, however, sometimes we get behind – and we'd love your help.
 
@@ -65,6 +65,7 @@ We commissioned and monitor the following libraries from our stellar group of co
 Thanks to the following developers for open-sourcing their own Diffbot client bindings.
 
 <ul>
+  <li><a href="https://github.com/therealpadster/diffbot-api-node" target="_new">Node.js (promise-based)</a> - from <a href="https://github.com/theRealPadster" target="_new">Isaac Maier</a>, supporting Analyze, Article, Discussion, Event, Image, Product, Video, Knowledge Graph, Crawl, Search, and Account APIs.</li>
   <li><a href="https://github.com/markbao/node-diffbot" target="_new">Node.js</a> - from <a href="http://www.onswipe.com" target="_new">OnSwipe</a></li>
   <li><a href="https://github.com/tansey/diffbot" target="_new">.NET</a> - from NLP geek-trepreneur Wesley Tansey</li>
   <li><a href="https://github.com/TheRightChoyce/diffbot-csharp" target="_new">C#</a> - from Chris Choyce, creater of Pistashio</li>
@@ -99,7 +100,7 @@ Thanks to the following developers for open-sourcing their own Diffbot client bi
 | [Custom APIs]  | Custom field extraction from any site using manual rules                                              |
 | [Crawlbot API] | For structuring entire sites using one of the above APIs                                              |
 | [Bulk API]     | Asynchronous processing of many URLs using one of the above APIs                                      |
-| [Search API]   | Real-time, field-specific search of your Crawlbot and Bulk API jobs      
+| [Search API]   | Real-time, field-specific search of your Crawlbot and Bulk API jobs
 
 [Analyze API]: #analyze-api
 [Article API]: #article-api


### PR DESCRIPTION
The existing javascript libraries I found were missing features I needed and were fairly out of date, so I created my own more feature-complete Diffbot library for Node.js using javascript promises instead of callbacks. 